### PR TITLE
feat(ui): add collapsible partner cards and compress people cards layout

### DIFF
--- a/app/[locale]/about-us/components/collaboratingPartner.tsx
+++ b/app/[locale]/about-us/components/collaboratingPartner.tsx
@@ -1,11 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { Button, Icon, Text } from 'opub-ui';
 
 import {
   CollaboratingPartnerHPText,
   CollaboratingPartnerTextOne,
-  CollaboratingPartnerTextTwo,
 } from '@/config/consts';
 import { handleRedirect } from '@/lib/utils';
 import Icons from '@/components/icons';
@@ -13,6 +12,23 @@ import { MediaRendering } from '@/components/media-rendering';
 
 export function CollaboratingPartner() {
   const [showMore, setShowMore] = useState(false);
+  const [isDescriptionLong, setIsDescriptionLong] = useState(false);
+
+  const descriptionRef = useRef<HTMLDivElement | null>(null);
+  const toggleShowMore = (event: React.MouseEvent) => {
+    event.preventDefault(); // Prevent link navigation
+    event.stopPropagation(); // Stop event from propagating to the card's link
+    setShowMore((prevState) => !prevState);
+  };
+
+  useEffect(() => {
+    if (descriptionRef.current) {
+      const isLong =
+        descriptionRef.current.scrollHeight >
+        descriptionRef.current.clientHeight;
+      setIsDescriptionLong(isLong);
+    }
+  }, []);
   return (
     <section
       className="flex h-full flex-col flex-wrap py-14 "
@@ -73,12 +89,32 @@ export function CollaboratingPartner() {
             </Text>
 
             <div className="flex flex-col gap-5">
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {CollaboratingPartnerTextOne}
-              </Text>
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {CollaboratingPartnerTextTwo}
-              </Text>
+              <div>
+                <div
+                  ref={descriptionRef}
+                  className={!showMore ? ' line-clamp-2 lg:line-clamp-5' : ''}
+                >
+                  <Text variant="bodyLg" fontWeight="regular" color="default">
+                    {/* {CollaboratingPartnerTextOne} */}
+                    {CollaboratingPartnerTextOne}
+                  </Text>
+                </div>
+
+                {/* Only show the "Show more" button on medium and small screens */}
+                {isDescriptionLong && (
+                  <div className="block md:hidden">
+                    <Button
+                      className="self-start p-2"
+                      onClick={toggleShowMore}
+                      variant="interactive"
+                      size="slim"
+                      kind="tertiary"
+                    >
+                      {showMore ? 'Show less' : 'Show more'}
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>
@@ -132,9 +168,31 @@ export function CollaboratingPartner() {
             </Text>
 
             <div className="flex flex-col gap-5">
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {CollaboratingPartnerHPText}
-              </Text>
+              <div>
+                <div
+                  ref={descriptionRef}
+                  className={!showMore ? ' line-clamp-2 lg:line-clamp-5' : ''}
+                >
+                  <Text variant="bodyLg" fontWeight="regular" color="default">
+                    {CollaboratingPartnerHPText}
+                  </Text>
+                </div>
+
+                {/* Only show the "Show more" button on medium and small screens */}
+                {isDescriptionLong && (
+                  <div className="block md:hidden">
+                    <Button
+                      className="self-start p-2"
+                      onClick={toggleShowMore}
+                      variant="interactive"
+                      size="slim"
+                      kind="tertiary"
+                    >
+                      {showMore ? 'Show less' : 'Show more'}
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/app/[locale]/about-us/components/supportedBy.tsx
+++ b/app/[locale]/about-us/components/supportedBy.tsx
@@ -1,10 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { Button, Icon, Text } from 'opub-ui';
 
 import {
-  OpenContractingPartnershipTextOne,
-  OpenContractingPartnershipTextTwo,
   PJMcPartnershipText,
   TheRockefellerFoundationTextOne,
 } from '@/config/consts';
@@ -14,6 +12,23 @@ import { MediaRendering } from '@/components/media-rendering';
 
 export function SupportedBy() {
   const [showMore, setShowMore] = useState(false);
+  const [isDescriptionLong, setIsDescriptionLong] = useState(false);
+
+  const descriptionRef = useRef<HTMLDivElement | null>(null);
+  const toggleShowMore = (event: React.MouseEvent) => {
+    event.preventDefault(); // Prevent link navigation
+    event.stopPropagation(); // Stop event from propagating to the card's link
+    setShowMore((prevState) => !prevState);
+  };
+
+  useEffect(() => {
+    if (descriptionRef.current) {
+      const isLong =
+        descriptionRef.current.scrollHeight >
+        descriptionRef.current.clientHeight;
+      setIsDescriptionLong(isLong);
+    }
+  }, []);
   return (
     <section
       className="flex  flex-col flex-wrap py-14 "
@@ -23,7 +38,7 @@ export function SupportedBy() {
         <Text variant="heading2xl" fontWeight="bold" color="default" as="h2">
           Supported By
         </Text>
-        <div className="flex flex-wrap items-center justify-center gap-10 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
+        <div className="flex flex-wrap items-center justify-center gap-10 rounded-2 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
           <div className="flex flex-col items-center gap-4 text-surfaceDefault">
             <Image
               src="/logo/Rockefeller.png"
@@ -75,28 +90,45 @@ export function SupportedBy() {
               The Rockefeller Foundation
             </Text>
             <div className="flex flex-col gap-5">
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {TheRockefellerFoundationTextOne}
-              </Text>
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                For more information, sign up for their newsletter at{' '}
-                <Button
-                  size="large"
-                  className="underline"
-                  kind="tertiary"
-                  variant="basic"
-                  onClick={(event) =>
-                    handleRedirect(event, 'https://rockefellerfoundation.org/')
-                  }
+              <div>
+                <div
+                  ref={descriptionRef}
+                  className={!showMore ? ' line-clamp-2 lg:line-clamp-5' : ''}
                 >
-                  rockefellerfoundation.org
-                </Button>{' '}
-                and follow them on X @RockefellerFdn.
-              </Text>
+                  <Text variant="bodyLg" fontWeight="regular" color="default">
+                    {TheRockefellerFoundationTextOne} For more information, sign
+                    up for their newsletter at{' '}
+                    <a
+                      href="https://rockefellerfoundation.org/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-link underline"
+                    >
+                      rockefellerfoundation.org
+                    </a>{' '}
+                    and follow them on X @RockefellerFdn
+                  </Text>
+                </div>
+
+                {/* Only show the "Show more" button on medium and small screens */}
+                {isDescriptionLong && (
+                  <div className="block md:hidden">
+                    <Button
+                      className="self-start p-2"
+                      onClick={toggleShowMore}
+                      variant="interactive"
+                      size="slim"
+                      kind="tertiary"
+                    >
+                      {showMore ? 'Show less' : 'Show more'}
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>
-        <div className="flex flex-wrap items-center justify-center gap-10 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
+        <div className="flex flex-wrap items-center justify-center gap-10 rounded-2 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
           <div className="flex flex-col items-center gap-4 text-surfaceDefault">
             <Image
               src="/logo/PJMc.png"
@@ -148,9 +180,31 @@ export function SupportedBy() {
               Patrick J. McGovern Foundation{' '}
             </Text>
             <div className="flex flex-col gap-5">
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {PJMcPartnershipText}
-              </Text>
+              <div>
+                <div
+                  ref={descriptionRef}
+                  className={!showMore ? ' line-clamp-2 lg:line-clamp-5' : ''}
+                >
+                  <Text variant="bodyLg" fontWeight="regular" color="default">
+                    {PJMcPartnershipText}
+                  </Text>
+                </div>
+
+                {/* Only show the "Show more" button on medium and small screens */}
+                {isDescriptionLong && (
+                  <div className="block md:hidden">
+                    <Button
+                      className="self-start p-2"
+                      onClick={toggleShowMore}
+                      variant="interactive"
+                      size="slim"
+                      kind="tertiary"
+                    >
+                      {showMore ? 'Show less' : 'Show more'}
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/app/[locale]/about-us/components/teams.tsx
+++ b/app/[locale]/about-us/components/teams.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { Button, Text } from 'opub-ui';
 
@@ -6,7 +7,6 @@ import {
   CDLPartnershipTextThree,
   CDLPartnershipTextTwo,
   OpenContractingPartnershipTextOne,
-  OpenContractingPartnershipTextTwo,
 } from '@/config/consts';
 import { handleRedirect } from '@/lib/utils';
 import styles from './styles.module.scss';
@@ -43,31 +43,33 @@ const teamMembers: TeamMember[] = [
     imageUrl: '/teams/bhavabhuthi.jpg',
   },
   {
-    name: 'Ruthvik',
-    role: 'Associate Lead Engineer',
-    imageUrl: '/teams/ruthvik.jpg',
+    name: 'Saqib',
+    role: 'Quality Assurance Engineer',
+    imageUrl: '/teams/saqib.jpg',
   },
+
+  { name: 'Swati', role: 'Frontend Engineer', imageUrl: '/teams/swati1.jpg' },
 
   {
     name: 'Sanjay',
     role: 'Frontend Engineer',
     imageUrl: '/teams/sanjay.jpg',
   },
-  {
-    name: 'Sumit',
-    role: 'Senior Design Researcher',
-    imageUrl: '/teams/sumit.jpg',
-  },
-  { name: 'Swati', role: 'Frontend Engineer', imageUrl: '/teams/swati1.jpg' },
-  {
-    name: 'Saqib',
-    role: 'Quality Assurance Engineer',
-    imageUrl: '/teams/saqib.jpg',
-  },
+
   {
     name: 'Abhinandita',
     role: 'Senior Product Designer',
     imageUrl: '/teams/abhinandita.jpg',
+  },
+  {
+    name: 'Ruthvik',
+    role: 'Associate Lead Engineer',
+    imageUrl: '/teams/ruthvik.jpg',
+  },
+  {
+    name: 'Sumit',
+    role: 'Senior Design Researcher',
+    imageUrl: '/teams/sumit.jpg',
   },
   {
     name: 'Kakoli',
@@ -85,6 +87,24 @@ const teamMembers: TeamMember[] = [
 ];
 
 export function TheTeam() {
+  const [showMore, setShowMore] = useState(false);
+  const [isDescriptionLong, setIsDescriptionLong] = useState(false);
+
+  const descriptionRef = useRef<HTMLDivElement | null>(null);
+  const toggleShowMore = (event: React.MouseEvent) => {
+    event.preventDefault(); // Prevent link navigation
+    event.stopPropagation(); // Stop event from propagating to the card's link
+    setShowMore((prevState) => !prevState);
+  };
+
+  useEffect(() => {
+    if (descriptionRef.current) {
+      const isLong =
+        descriptionRef.current.scrollHeight >
+        descriptionRef.current.clientHeight;
+      setIsDescriptionLong(isLong);
+    }
+  }, []);
   return (
     <section
       className=" py-14 "
@@ -96,7 +116,7 @@ export function TheTeam() {
           Co-created by
         </Text>
 
-        <div className="flex flex-wrap items-center justify-center gap-10 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
+        <div className="flex flex-wrap items-center justify-center gap-10 rounded-2 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
           <div className="flex flex-col items-center gap-4 text-surfaceDefault">
             <Image
               src="/logo/OpenContracting.png"
@@ -148,16 +168,35 @@ export function TheTeam() {
               Open Contracting Partnership
             </Text>
             <div className="flex flex-col gap-5">
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {OpenContractingPartnershipTextOne}
-              </Text>
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {OpenContractingPartnershipTextTwo}
-              </Text>
+              <div>
+                <div
+                  ref={descriptionRef}
+                  className={!showMore ? ' line-clamp-2 lg:line-clamp-5' : ''}
+                >
+                  <Text variant="bodyLg" fontWeight="regular" color="default">
+                    {OpenContractingPartnershipTextOne}
+                  </Text>
+                </div>
+
+                {/* Only show the "Show more" button on medium and small screens */}
+                {isDescriptionLong && (
+                  <div className="block md:hidden">
+                    <Button
+                      className="self-start p-2"
+                      onClick={toggleShowMore}
+                      variant="interactive"
+                      size="slim"
+                      kind="tertiary"
+                    >
+                      {showMore ? 'Show less' : 'Show more'}
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>
-        <div className="flex flex-wrap items-center justify-center gap-10 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
+        <div className="flex flex-wrap items-center justify-center gap-10 rounded-2 bg-baseIndigoSolid1 p-9 lg:flex-nowrap ">
           <div className="flex flex-col items-center gap-4 text-surfaceDefault">
             <Image
               src="/logo/cdl_logo.svg"
@@ -212,16 +251,39 @@ export function TheTeam() {
               <Text variant="bodyLg" fontWeight="regular" color="default">
                 {CDLPartnershipTextOne}
               </Text>
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {CDLPartnershipTextTwo}
-              </Text>
-              <Text variant="bodyLg" fontWeight="regular" color="default">
-                {CDLPartnershipTextThree}
-              </Text>
+              {/* --------------  */}
+
+              <div>
+                <div
+                  ref={descriptionRef}
+                  className={!showMore ? ' line-clamp-2 lg:line-clamp-5' : ''}
+                >
+                  <Text variant="bodyLg" fontWeight="regular" color="default">
+                    {CDLPartnershipTextTwo} {CDLPartnershipTextThree}
+                  </Text>
+                </div>
+
+                {/* Only show the "Show more" button on medium and small screens */}
+                {isDescriptionLong && (
+                  <div className="block md:hidden">
+                    <Button
+                      className="self-start p-2"
+                      onClick={toggleShowMore}
+                      variant="interactive"
+                      size="slim"
+                      kind="tertiary"
+                    >
+                      {showMore ? 'Show less' : 'Show more'}
+                    </Button>
+                  </div>
+                )}
+              </div>
+              {/* --------------  */}
             </div>
           </div>
         </div>
-        <div className="mt-6 grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-3 ">
+        {/* <div className="mt-6 grid grid-cols-1 gap-10 rounded-2 md:grid-cols-2 lg:grid-cols-3 "> */}
+        <div className="mt-6 grid grid-cols-2 gap-6 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3">
           {teamMembers.map((member, index) => (
             <div key={index} className={styles.card}>
               <Image

--- a/config/consts.ts
+++ b/config/consts.ts
@@ -86,7 +86,7 @@ const AboutTextContentThree = 'We have a 3-pronged approach: ';
 const HeroSectionText = 'Discover insights, assess risks and build resilience';
 
 const AnalyticsQuickLinksText =
-  'Gain insights from the IDS-DRR data model to understand the flood-risk profiles of districts and sub-district regions in various states across India';
+  'Explore flood-risk profiles at the district and sub-district level across states in India, developed using the IDS-DRR data model';
 
 const DatasetCatalogText = 'Explore and use high-value datasets';
 
@@ -110,10 +110,10 @@ const IntroTextContentThree =
   'This 4-year project led by CivicDataLab & Open Contracting Partnership is planned to improve disaster risk reduction processes & practices in the state of Assam. It is supported by The Rockefeller Foundation.';
 
 const CollaboratingPartnerTextOne =
-  'The Assam State Disaster Management Authority was notified in the year 2007 with the adoption of the Disaster Management Act in the year 2006. Honourable Chief Minister, Assam is its Chairperson and Honorable Minister Revenue and Disaster Management is its Vice Chairperson. To execute the mandate of the Authority the State Executive Committee with the Chief Secretary, Assam as its Chairperson has also been notified as per provision of the Disaster Management Act. The ASDMA Secretariat with officers, consultants and employees, for carrying out the functions of the State Authority, became fully functional in the year 2010. ';
+  'The Assam State Disaster Management Authority was notified in the year 2007 with the adoption of the Disaster Management Act in the year 2006. Honourable Chief Minister, Assam is its Chairperson and Honorable Minister Revenue and Disaster Management is its Vice Chairperson. To execute the mandate of the Authority the State Executive Committee with the Chief Secretary, Assam as its Chairperson has also been notified as per provision of the Disaster Management Act. The ASDMA Secretariat with officers, consultants and employees, for carrying out the functions of the State Authority, became fully functional in the year 2010. ASDMA has also notified the District Disaster Management Authority in all the 33 districts of Assam and placed officers for carrying out disaster management activities at the district.';
 
-const CollaboratingPartnerTextTwo =
-  'ASDMA has also notified the District Disaster Management Authority in all the 33 districts of Assam and placed officers for carrying out disaster management activities at the district.';
+// const CollaboratingPartnerTextTwo =
+// 'ASDMA has also notified the District Disaster Management Authority in all the 33 districts of Assam and placed officers for carrying out disaster management activities at the district.';
 
 const CollaboratingPartnerHPText =
   'The HP SDMA has been constituted under the chairmanship of Chief  Minister of Himachal Pradesh. Revenue Minister has been nominated as  member. Chief Secretary is the Chief Executive Officer of the SDMA. ACS  cum FC (Revenue), Principal Secretary (Home), Principal Secretary (PWD/I  & PH), Principal Secretary (Health) and Director General of Police  have also been notified as member. Additional Chief Secretary (Revenue)  is the Member Secretary of the Authority.';
@@ -123,10 +123,10 @@ const TheRockefellerFoundationTextOne =
 const TheRockefellerFoundationTextTwo =
   'For more information, sign up for their newsletter at rockefellerfoundation.org and follow them on X @RockefellerFdn.';
 const OpenContractingPartnershipTextOne =
-  'Open Contracting Partnership is an independent non-profit working in over 50 countries. OCP is a silo-busting collaboration across governments, businesses, civil society, and technologists to improve public procurement by designing goal-driven reforms, building coalitions of change and co-creating digital solutions, powered by open data. ';
+  'Open Contracting Partnership is an independent non-profit working in over 50 countries. OCP is a silo-busting collaboration across governments, businesses, civil society, and technologists to improve public procurement by designing goal-driven reforms, building coalitions of change and co-creating digital solutions, powered by open data. OCP is unique in bringing these three approaches together and at scale. OCP makes sure public money is spent openly, fairly and effectively on public contracts, delivering fundamentally better public spending outcomes that benefit people and protect the planet.';
 
-const OpenContractingPartnershipTextTwo =
-  'OCP is unique in bringing these three approaches together and at scale. OCP makes sure public money is spent openly, fairly and effectively on public contracts, delivering fundamentally better public spending outcomes that benefit people and protect the planet.';
+// const OpenContractingPartnershipTextTwo =
+//   'OCP is unique in bringing these three approaches together and at scale. OCP makes sure public money is spent openly, fairly and effectively on public contracts, delivering fundamentally better public spending outcomes that benefit people and protect the planet.';
 
 const PJMcPartnershipText =
   'The Patrick J. McGovern Foundation (PJMF) is a philanthropic organization dedicated to advancing artificial intelligence and data science solutions to create a thriving, equitable, and sustainable future for all. PJMF works in partnership with public, private, and social institutions to drive progress on our most pressing challenges, including digital health, climate change, broad digital access, and data maturity in the social sector.';
@@ -164,9 +164,9 @@ export {
   IntroTextContentThree,
   aboutUsText,
   CollaboratingPartnerTextOne,
-  CollaboratingPartnerTextTwo,
+  // CollaboratingPartnerTextTwo,
   OpenContractingPartnershipTextOne,
-  OpenContractingPartnershipTextTwo,
+  // OpenContractingPartnershipTextTwo,
   TheRockefellerFoundationTextOne,
   TheRockefellerFoundationTextTwo,
   learnMoreLink,


### PR DESCRIPTION
- Added "Read more" link to partner cards for collapsible content, expanding and contracting after three lines
- Updated people cards layout to display two cards per row for a more compact presentation