### PR TITLE
Add ID and timestamp to resource filenames. fixes issue #279

### DIFF
--- a/app/[locale]/datasets/[dataset]/components/dataset-explorer.tsx
+++ b/app/[locale]/datasets/[dataset]/components/dataset-explorer.tsx
@@ -40,7 +40,7 @@ export function Content({ slug }: { slug: string }) {
             <DatasetResources
               key={index}
               id={resource?.id}
-              fileName={resource?.title || 'NA'}
+              fileName={`${resource?.title || 'File'} [${resource?.id}] - ${formatDate(resource?.modified) || 'N/A'}`}
               modified={resource?.modified}
               format={resource?.file_details?.format || 'NA'}
               description={resource?.description}


### PR DESCRIPTION
This commit updates the dataset resource view to show the ID and last modified date alongside the filename.

#279 