### PR TITLE
fix: app/[locale]/[state]/analytics/page.tsx is a server component and ought to use DATA_MANAGEMENT_LAYER_URL consistently, not NEXT_PUBLIC_DATA_MANAGEMENT_LAYER_URL

### DIFF
--- a/app/[locale]/[state]/analytics/page.tsx
+++ b/app/[locale]/[state]/analytics/page.tsx
@@ -31,7 +31,7 @@ export default async function Home({
       queryKey: [`states_list`],
       queryFn: () =>
         GraphQL(
-          `${process.env.NEXT_PUBLIC_DATA_MANAGEMENT_LAYER_URL}/graphql`,
+          `${process.env.DATA_MANAGEMENT_LAYER_URL}/graphql`,
           PLATFORM_STATES_LIST
         ),
     });


### PR DESCRIPTION
A few lines above it uses the correct base URL.