### PR TITLE
fix: Fix "Query data cannot be undefined. Please make sure to return a value other than undefined from your query function."

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -18,6 +18,7 @@ export async function GraphQL<TResult, TVariables>(
     return data;
   } catch (error: any) {
     captureException(error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
Returning undefined is interpreted by React Query as the query succeeding with an undefined value, which it rejects as invalid.

By re-throwing the error, React Query knows the query failed and handles it.
