### PR TITLE
fix: Don't crash the analytics page on partial date-picker input

### DIFF
--- a/app/[locale]/[state]/analytics/components/filter-dropdown-options.tsx
+++ b/app/[locale]/[state]/analytics/components/filter-dropdown-options.tsx
@@ -1,9 +1,9 @@
-import { parseDate } from '@internationalized/date';
+import { parseDate, type CalendarDate } from '@internationalized/date';
 import { parseAsString, useQueryState } from 'next-usequerystate';
 import { MonthPicker, MultiMonthPicker, Select } from 'opub-ui';
 
 import { toTitleCase } from '@/lib/utils';
-import { getLatestDate } from '../utils/utils';
+import { getLatestDate, safeParseDate } from '../utils/utils';
 
 export interface Option {
   disabled?: boolean;
@@ -125,7 +125,7 @@ export default function FilterDropdownOptions({
     selectedTimePeriod &&
     Array.isArray(selectedTimePeriod) &&
     selectedTimePeriod.filter(Boolean).length > 0
-      ? parseDate(
+      ? safeParseDate(
           getLatestDate(selectedTimePeriod.filter(Boolean)) || '2023-08-01'
         )
       : hasExplicitEmptyTimePeriod
@@ -170,8 +170,9 @@ export default function FilterDropdownOptions({
                   ?.filter(Boolean)
                   ?.map((timePeriod: string) => {
                     const [year, month] = timePeriod.split('_');
-                    return parseDate(`${year}-${month.padStart(2, '0')}-01`);
-                  }) || []
+                    return safeParseDate(`${year}-${month?.padStart(2, '0')}-01`);
+                  })
+                  ?.filter((d): d is CalendarDate => d !== undefined) || []
               }
               // defaultValues={getDefaultDate(timePeriod || '')}
               label="Select Months"

--- a/app/[locale]/[state]/analytics/utils/utils.ts
+++ b/app/[locale]/[state]/analytics/utils/utils.ts
@@ -1,3 +1,13 @@
+import { parseDate, type CalendarDate } from '@internationalized/date';
+
+export function safeParseDate(value: string): CalendarDate | undefined {
+  try {
+    return parseDate(value);
+  } catch {
+    return undefined;
+  }
+}
+
 export const constructRegionOptions = (
   boundary: string,
   geographiesData: any
@@ -100,12 +110,14 @@ export function formatNumberToIndianSystem(input: number): string | number {
 
 
 export const getLatestDate = (dateStrings: string[]) => {
-  if (!dateStrings || dateStrings.length === 0) {
+  const valid = (dateStrings || []).filter((dateStr) => /^\d{4}_\d{2}$/.test(dateStr));
+
+  if (valid.length === 0) {
     return process.env.NEXT_PUBLIC_TIME_PERIOD; // Handle empty array case
   }
 
   // Convert each 'yyyy_mm' string to a Date object
-  const dates = dateStrings.map((dateStr) => {
+  const dates = valid.map((dateStr) => {
     const [year, month] = dateStr.split('_'); // Split into year and month
     return new Date(parseInt(year), parseInt(month) - 1); // Create a Date object (month is 0-indexed in JavaScript)
   });

--- a/tests/filter-dropdown-options.test.tsx
+++ b/tests/filter-dropdown-options.test.tsx
@@ -54,15 +54,6 @@ jest.mock('@/lib/utils', () => ({
   }),
 }));
 
-jest.mock('@/app/[locale]/[state]/analytics/utils/utils', () => ({
-  getLatestDate: jest.fn((dates: string[]) => {
-    if (!dates || dates.length === 0) return '2023-08-01';
-    const latest = dates.sort().pop();
-    const [year, month] = latest!.split('_');
-    return `${year}-${month.padStart(2, '0')}-01`;
-  }),
-}));
-
 // Mock @internationalized/date
 jest.mock('@internationalized/date', () => ({
   parseDate: jest.fn((dateString: string) => {


### PR DESCRIPTION
opub-ui's MonthPicker and MultiMonthPicker store dates in the URL as
YYYY_MM. If a user is midway through typing 2026, a value like 202_10
can be stored. This value is transformed into 202-10-01 and passed to
parseDate(), which throws an error.

Add a safeParseDate wrapper to catch the error.
