### PR TITLE
fix: 404 the analytics page when the state slug has no match

### DIFF
--- a/app/[locale]/[state]/analytics/layout.tsx
+++ b/app/[locale]/[state]/analytics/layout.tsx
@@ -1,4 +1,5 @@
 import React, { cache } from 'react';
+import { notFound } from 'next/navigation';
 
 import { PLATFORM_STATES_LIST } from '@/config/graphql/analaytics-queries';
 import { getQueryClient, GraphQL } from '@/lib/api';
@@ -34,11 +35,16 @@ export default async function AnalyticsLayout({
   const resolvedParams = await params;
   const state = resolvedParams.state;
   const statesListData = await getStatesList();
+  const currentState = statesListData?.find(
+    (item: any) => item.slug === state
+  );
+
+  if (!currentState) notFound();
 
   return (
     <>
       <AnalyticsSideBarLayout
-        currentState={statesListData?.find((item: any) => item.slug === state)}
+        currentState={currentState}
         statesList={statesListData}
       >
         {children}


### PR DESCRIPTION
statesListData?.find(...) returns undefined when the backend is empty
or the URL references a state that wasn't imported. When `undefined`
is later destructured (e.g. currentState.code), the page crashes.

Extract the lookup and call notFound() when it misses, producing a
proper 404 instead of a runtime crash.
