### PR TITLE
fix: Stop `_leaflet_pos` error on analytics page resize

### DIFF
--- a/app/[locale]/[state]/analytics/components/map-component.tsx
+++ b/app/[locale]/[state]/analytics/components/map-component.tsx
@@ -248,21 +248,12 @@ export const MapComponent = ({
   }, [districtCode, map, mapData?.features, revenueMapData?.features]);
 
   React.useEffect(() => {
-    try {
-      setTimeout(() => {
-        if (
-          map &&
-          map?.getContainer() &&
-          currentSelectedState.center &&
-          !districtCode &&
-          currentSelectedState.code !== '18'
-        ) {
-          map?.setView(currentSelectedState.center, 7.4);
-        }
-      }, 100);
-    } catch (error) {
-      console.log(error);
-    }
+    if (!map) return;
+    if (districtCode) return;
+    if (!currentSelectedState.center) return;
+    if (currentSelectedState.code === '18') return;
+
+    map.setView(currentSelectedState.center, 7.4);
   }, [map, districtCode, currentSelectedState]);
 
   if (mapDataloading || revenueMapDataLoading)


### PR DESCRIPTION
The MapComponent's state-centering effect scheduled setView through a
100ms setTimeout without a clearTimeout cleanup. Breakpoint resizes
across 1024px unmount one of the two <MapComponent> subtrees (the
desktop and mobile layouts render their own, gated by MediaRendering),
which in turn triggers react-leaflet's map.remove(), deleting
_mapPane off the Leaflet Map instance. Any pending timer from the
unmounted instance then fires against the removed map, setView
reaches _getMapPanePos, which calls getPosition(undefined), which
throws `undefined is not an object (evaluating 'el._leaflet_pos')`.

This effect depends on the `map` state value, which is set by the
`setMap` prop we pass to MapChart. That prop is fired by react-leaflet's
MapContainer only after it has mounted and run its initial setView. So,
the map is loaded and safe to reposition by the time our effect runs.

Drop the setTimeout and call setView directly.
