### PR TITLE
Run `npm run lint` in CI

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -33,6 +33,7 @@ jobs:
       - if: steps.npm_ci.outcome == 'failure'
         run: npm install --force
       - run: npm run lint
+      - run: npm run type-check
       - run: npm run test
       - run: npm run build
       - if: steps.npm_ci.outcome == 'failure'

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -14,28 +14,20 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22.x
           cache: 'npm'
-
+      - uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - run: npm ci --force
-
-      # - name: Run linting
-      #   run: npm run lint --if-present
-
-      # - name: Run type checking
-      #   run: npm run type-check --if-present
-
-      - name: Run tests
-        run: npm test --if-present
-
-      - name: Run build
-        run: npm run build --if-present
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -27,7 +27,15 @@ jobs:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
           restore-keys: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-      - run: npm ci --force
+      - id: npm_ci
+        run: npm ci --force
+        continue-on-error: true
+      - if: steps.npm_ci.outcome == 'failure'
+        run: npm install --force
       - run: npm run lint
       - run: npm run test
       - run: npm run build
+      - if: steps.npm_ci.outcome == 'failure'
+        run: |
+          echo "::error::npm ci failed: Run `npm install --force` to update package-lock.json"
+          exit 1

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -24,28 +24,9 @@ const config: Config = {
     '^d3-scale$': '<rootDir>/tests/__mocks__/d3-scale.ts',
     '^d3-scale-chromatic$': '<rootDir>/tests/__mocks__/d3-scale-chromatic.ts',
   },
-  // transformIgnorePatterns: [
-  //   'node_modules/(?!(d3-scale|d3-array|d3-color|d3-format|d3-interpolate|d3-time|d3-time-format|d3-timer|d3-transition|d3-zoom|d3-drag|d3-dispatch|d3-ease|d3-selection|d3-shape|d3-path|d3-polygon|d3-quadtree|d3-random|d3-sankey|d3-force|d3-hierarchy|d3-chord|d3-contour|d3-delaunay|d3-geo|d3-geo-projection|d3-hexbin|d3-histogram|d3-scale-chromatic|d3-symbol|d3-threshold|d3-tile|d3-treemap|d3-voronoi|d3-zoom)/)',
-  // ],
-  collectCoverage: false,
-  // collectCoverageFrom: [
-  //   'app/**/*.{js,jsx,ts,tsx}',
-  //   'src/**/*.{js,jsx,ts,tsx}',
-  //   '!**/*.d.ts',
-  //   '!**/node_modules/**',
-  //   '!**/vendor/**',
-  // ],
-  // coverageDirectory: 'coverage',
-  // coveragePathIgnorePatterns: [
-  //   '/node_modules/',
-  //   '/coverage',
-  //   'package.json',
-  //   'package-lock.json',
-  //   'reportWebVitals.ts',
-  //   'setup.ts',
-  //   'index.tsx',
-  // ],
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  collectCoverageFrom: [
+    '{app,components,config,hooks,i18n,lib}/**/*.{ts,tsx}',
+  ],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "generate": "graphql-codegen --require dotenv/config --config ./config/codegen.ts --watch",
     "clean": "rm -rf node_modules package-lock.json",
     "test": "jest",
-    "test:watch": "jest - watch",
-    "test:coverage": "jest - coverage"
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "clean": "rm -rf node_modules package-lock.json",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.2.0",


### PR DESCRIPTION
closes https://github.com/CivicDataLab/IDS-DRR-Frontend/issues/365

- Allow other steps to run if npm ci failed (but still fail the workflow if it did)
- Update jest's coverage configuration for local coverage reports
- Speed up CI by caching the Next.js build

CI fails due to `tests/revenue-circle-accordion.test.tsx` which is removed in #349