### PR TITLE
perf: Memoize currentSelectedState in analytics layout

### DIFF
--- a/app/[locale]/[state]/analytics/components/analytics-layout.tsx
+++ b/app/[locale]/[state]/analytics/components/analytics-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { parseAsString, useQueryState } from 'next-usequerystate';
@@ -66,8 +66,12 @@ export function AnalyticsMainLayout() {
       ),
   });
 
-  const currentSelectedState = statesListData?.data?.getStates?.find(
-    (item: any) => item.slug === routerParams.state
+  const currentSelectedState = useMemo(
+    () =>
+      statesListData?.data?.getStates?.find(
+        (item: any) => item.slug === routerParams.state
+      ),
+    [statesListData?.data?.getStates, routerParams.state]
   );
 
   const stateLatestTimePeriod =


### PR DESCRIPTION
statesListData.data.getStates.find() returns a new array element reference on every render. Passing it down as a prop and listing it in child useEffect deps re-fires the children every render.

In an upcoming PR, I'm adding fitBounds effects to the map-component (instead of hardcoding zoom levels), and those in particular churn against an unchanged state.
