### PR TITLE
fix: Center analytics quick-links carousel when one state is configured

### DIFF
--- a/app/[locale]/components/analytics-quick-links.tsx
+++ b/app/[locale]/components/analytics-quick-links.tsx
@@ -75,13 +75,19 @@ export const QuickLinks = () => {
           <div className="mr-2 rounded-1 bg-surfaceDefault">
             <CarouselPrevious />
           </div>
-          <CarouselContent className="container flex w-full gap-0 px-4 md:gap-6 lg:gap-2">
-            {/* Adjust padding */}
-            {analyticsWithResolvedLinks.map((item, index) => {
-              return (
+          <CarouselContent
+            className={`container flex w-full gap-0 px-4 md:gap-6 lg:gap-2 ${
+              analyticsWithResolvedLinks.length === 1 ? 'justify-center' : ''
+            }`}
+          >
+            {analyticsWithResolvedLinks.map((item, index) => (
               <CarouselItem
                 key={index}
-                className="lg flex items-center justify-center overflow-hidden px-1 md:basis-1/2 lg:basis-1/3 xl:basis-1/4 xl:px-7 2xl:basis-1/5"
+                className={`flex items-center justify-center overflow-hidden px-1 xl:px-7 ${
+                  analyticsWithResolvedLinks.length === 1
+                    ? 'basis-auto'
+                    : 'md:basis-1/2 lg:basis-1/3 xl:basis-1/4 2xl:basis-1/5'
+                }`}
               >
                 {item.status === 'active' ? (
                   <Link
@@ -126,8 +132,7 @@ export const QuickLinks = () => {
                   </div>
                 )}
               </CarouselItem>
-              );
-            })}
+            ))}
           </CarouselContent>
           <div className="ml-2 rounded-1 bg-surfaceDefault">
             <CarouselNext />


### PR DESCRIPTION
Use basis-auto + justify-center for the one-card case.

Drop unrecognized lg class.

----

For the DPG demo I'm preparing, the homepage would be broken visually when there's just one item.