### PR TITLE
fix: Fix off-by-one errors in mobile date picker

### DIFF
--- a/app/[locale]/[state]/analytics/components/filter-component.tsx
+++ b/app/[locale]/[state]/analytics/components/filter-component.tsx
@@ -251,7 +251,7 @@ const RenderOptions = ({
 
   const datesArray = normalizedTimePeriods.map((date: string) => {
     const [year, month] = date.split('_');
-    return new Date(parseInt(year), parseInt(month));
+    return new Date(Date.UTC(parseInt(year), parseInt(month) - 1));
   });
   const timestamps = datesArray.map((date: any) => date.getTime());
   if (timestamps.length > 0) {


### PR DESCRIPTION
Previously, the YearCalendar in the mobile layout hid the earliest data
month and exposed one empty month past the latest. Clients east of UTC
would see a different version of the bug due to timezone shifts.


---

You can see e.g. Apr 2021 can't be selected on mobile, but it can on desktop.