### PR TITLE
i18n: Translate dates and times

### DIFF
--- a/app/[locale]/[state]/analytics/components/filter-component.tsx
+++ b/app/[locale]/[state]/analytics/components/filter-component.tsx
@@ -8,7 +8,7 @@ import { useTranslations } from 'next-intl';
 import { Button, Icon, RadioGroup, RadioItem, YearCalendar } from 'opub-ui';
 
 import { routes, type AnalyticsView } from '@/lib/routes';
-import { formatDate } from '@/lib/utils';
+import { toISODate } from '@/lib/utils';
 import Icons from '@/components/icons';
 import {
   MobileFilterBox,
@@ -257,8 +257,8 @@ const RenderOptions = ({
   if (timestamps.length > 0) {
     const minTimestamp = Math.min(...timestamps);
     const maxTimestamp = Math.max(...timestamps);
-    minDate = formatDate(minTimestamp, true);
-    maxDate = formatDate(maxTimestamp, true);
+    minDate = toISODate(minTimestamp);
+    maxDate = toISODate(maxTimestamp);
   } else {
     const [year, month] = (timePeriodSelected || '2023_08').split('_');
     minDate = `${year}-${month}-01`;

--- a/app/[locale]/[state]/analytics/components/output-window.tsx
+++ b/app/[locale]/[state]/analytics/components/output-window.tsx
@@ -12,7 +12,7 @@ import {
 import { InfoSquare } from '@/components/InfoCircle';
 import { useQuery } from '@tanstack/react-query';
 import { useQueryState } from 'next-usequerystate';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { Button, Icon, Text, Tooltip } from 'opub-ui';
 
 import { ANALYTICS_TIME_PERIODS } from '@/config/graphql/analaytics-queries';
@@ -20,7 +20,7 @@ import { GraphQL } from '@/lib/api';
 import { docsLink } from '@/config/site';
 import { useFormatNumber } from '@/hooks/use-format-number';
 import { Factors } from '@/lib/analytics';
-import { cn, formatDateString } from '@/lib/utils';
+import { cn, parsePeriodString } from '@/lib/utils';
 import Icons from '@/components/icons';
 import { MediaRendering } from '@/components/media-rendering';
 import { getFactorNameBySlug, getLatestDate } from '../utils/utils';
@@ -39,6 +39,7 @@ export function OutputWindow({
   const tCommon = useTranslations('common');
   const tRisk = useTranslations('analytics.risk');
   const tAnalytics = useTranslations('analytics');
+  const format = useFormatter();
   const formatNumber = useFormatNumber();
   const searchParams = useSearchParams();
   let processedTime = getLatestDate(
@@ -65,7 +66,10 @@ export function OutputWindow({
     ? `${processedTime[0]}_${processedTime[1]}`
     : (latestTimePeriod as string);
 
-  const formattedTimePeriod = formatDateString(timePeriod);
+  const timePeriodDate = parsePeriodString(timePeriod);
+  const formattedTimePeriod = timePeriodDate
+    ? format.dateTime(timePeriodDate, 'monthYearShort')
+    : '';
   const region = searchParams.get('district-code') || '';
   const view = searchParams.get('view') || '';
 

--- a/app/[locale]/components/resources.tsx
+++ b/app/[locale]/components/resources.tsx
@@ -18,7 +18,7 @@ import {
 import { resources } from '@/config/site';
 import { fetchDatasets } from '@/lib/api';
 import { routes } from '@/lib/routes';
-import { formatReferenceDate } from '@/lib/utils';
+import { useFormatPeriod } from '@/hooks/use-format-period';
 
 interface MetadataItem {
   label: string;
@@ -46,6 +46,7 @@ const Resources = () => {
   const t = useTranslations('home.resources');
   const tDatasets = useTranslations('datasets');
   const tCommon = useTranslations('common');
+  const formatPeriod = useFormatPeriod();
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -143,8 +144,8 @@ const Resources = () => {
                           fontWeight="regular"
                         >
                           {tDatasets('labels.referencePeriod')}{tDatasets('periodRange', {
-                            from: formatReferenceDate(card.referencePeriodFrom) || tCommon('na'),
-                            to: formatReferenceDate(card.referencePeriodTo) || tCommon('na'),
+                            from: formatPeriod(card.referencePeriodFrom),
+                            to: formatPeriod(card.referencePeriodTo),
                           })}
                         </Text>
                       </div>
@@ -211,14 +212,8 @@ const Resources = () => {
                           fontWeight="regular"
                         >
                           {tDatasets('labels.referencePeriod')}{tDatasets('periodRange', {
-                            from:
-                              formatReferenceDate(
-                                getMetadataValue(item, 'Period From')
-                              ) || tCommon('na'),
-                            to:
-                              formatReferenceDate(
-                                getMetadataValue(item, 'Period To')
-                              ) || tCommon('na'),
+                            from: formatPeriod(getMetadataValue(item, 'Period From')),
+                            to: formatPeriod(getMetadataValue(item, 'Period To')),
                           })}
                         </Text>
                       </div>

--- a/app/[locale]/components/stories.tsx
+++ b/app/[locale]/components/stories.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import {
   Carousel,
   CarouselContent,
@@ -12,10 +12,10 @@ import {
 } from 'opub-ui';
 
 import { stories } from '@/config/site';
-import { formatDate } from '@/lib/utils';
 
 export const Stories = () => {
   const t = useTranslations('home.stories');
+  const format = useFormatter();
   return (
     <div
       className="flex w-full justify-center"
@@ -72,7 +72,7 @@ export const Stories = () => {
                         </Text>
                       </div>
                       <div className="flex flex-wrap justify-between">
-                        <Text>{formatDate(story.date)}</Text>
+                        <Text>{format.dateTime(new Date(story.date), 'longDate')}</Text>
                       </div>
                       <div>
                         <Text>{story.description}</Text>

--- a/app/[locale]/datasets/[dataset]/components/Resources/index.tsx
+++ b/app/[locale]/datasets/[dataset]/components/Resources/index.tsx
@@ -4,15 +4,15 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { Button, Spinner, Tag, Text } from 'opub-ui';
 
 import { DATASET_RESOURCES_QUERY } from '@/config/graphql/dataset-queries';
 import { GraphQL } from '@/lib/api';
-import { formatDate } from '@/lib/utils';
 
 const Resources = () => {
   const t = useTranslations('datasets');
+  const format = useFormatter();
   const params = useParams();
 
   const { data, isLoading }: { data: any; isLoading: boolean } = useQuery({
@@ -79,7 +79,7 @@ const Resources = () => {
                   </div>
                   <div>
                     <Text>{t('labels.updated')}</Text>
-                    <Text>{formatDate(item.modified)}</Text>
+                    <Text>{format.dateTime(new Date(item.modified), 'longDate')}</Text>
                   </div>
                   <div className="flex flex-col">
                     <div

--- a/app/[locale]/datasets/components/DatasetCards.tsx
+++ b/app/[locale]/datasets/components/DatasetCards.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 import { Button, Tag, Text, Tooltip } from 'opub-ui';
 
 import { routes } from '@/lib/routes';
-import { formatReferenceDate } from '@/lib/utils';
+import { useFormatPeriod } from '@/hooks/use-format-period';
 
 interface MetadataItem {
   label: string;
@@ -31,6 +31,7 @@ interface Dataset {
 const Cards = ({ data }: { data: Dataset }) => {
   const t = useTranslations('datasets');
   const tCommon = useTranslations('common');
+  const formatPeriod = useFormatPeriod();
   function getMetadataValue(data: Dataset, label: string): string | null {
     const metadataEntry = data.metadata.find(
       (entry) => entry.metadata_item.label === label
@@ -116,14 +117,8 @@ const Cards = ({ data }: { data: Dataset }) => {
                     fontWeight="regular"
                   >
                     {t('labels.referencePeriod')}{t('periodRange', {
-                      from:
-                        formatReferenceDate(
-                          getMetadataValue(data, 'Period From')
-                        ) || tCommon('na'),
-                      to:
-                        formatReferenceDate(
-                          getMetadataValue(data, 'Period To')
-                        ) || tCommon('na'),
+                      from: formatPeriod(getMetadataValue(data, 'Period From')),
+                      to: formatPeriod(getMetadataValue(data, 'Period To')),
                     })}
                   </Text>
                 </span>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import {
 } from 'next-intl/server';
 
 import { Footer } from '@/config/branding';
+import { formats } from '@/i18n/formats';
 import {
   appleIcon,
   favicon,
@@ -124,7 +125,7 @@ export default async function LocaleLayout({
         )}
       </head>
       <body className={fontSans.className}>
-        <NextIntlClientProvider locale={locale} messages={messages}>
+        <NextIntlClientProvider locale={locale} messages={messages} formats={formats}>
           <Provider>
             <div className="min-h-screen flex flex-col">
               <MediaRendering minWidth={null} maxWidth="1023">

--- a/hooks/use-format-period.ts
+++ b/hooks/use-format-period.ts
@@ -1,0 +1,10 @@
+import { useFormatter, useTranslations } from 'next-intl';
+
+// Formats an ISO date string as a month-year string, e.g. "September 2024"
+// in en-US. Blank inputs fall back to the localized `common.na` message.
+export function useFormatPeriod() {
+  const t = useTranslations('common');
+  const format = useFormatter();
+  return (input: string | null | undefined): string =>
+    input ? format.dateTime(new Date(input), 'monthYear') : t('na');
+}

--- a/i18n/formats.ts
+++ b/i18n/formats.ts
@@ -1,0 +1,21 @@
+export const formats = {
+  dateTime: {
+    // "September 16, 2024" in en-US
+    longDate: {
+      dateStyle: 'long',
+      timeZone: 'UTC',
+    },
+    // "September 2024" in en-US
+    monthYear: {
+      year: 'numeric',
+      month: 'long',
+      timeZone: 'UTC',
+    },
+    // "Sep 2024" in en-US
+    monthYearShort: {
+      year: 'numeric',
+      month: 'short',
+      timeZone: 'UTC',
+    },
+  },
+} as const;

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -4,6 +4,7 @@ import { getRequestConfig } from 'next-intl/server';
 
 import { FALLBACK_LOCALE, locales, messages } from '../config/site';
 import defaultMessages from '../locales/en.json';
+import { formats } from './formats';
 
 // Recursive merge: values from `overrides` replace keys in `base` at any depth.
 // Plain objects are merged; everything else (strings, arrays, primitives) overrides.
@@ -56,5 +57,5 @@ export default getRequestConfig(async ({ requestLocale }) => {
     merged = deepMerge(merged, branding);
   }
 
-  return { locale, messages: merged };
+  return { locale, messages: merged, formats };
 });

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -4,45 +4,17 @@ export function cn(...inputs: ClassNameValue[]) {
   return twMerge(inputs);
 }
 
-export function formatDate(
-  input: string | number,
-  isHyphenated = false
-): string {
-  const date = new Date(input);
-  // If hyphendated it would return date in this format - 2023-01-01 else in April 1, 2021
-  return isHyphenated
-    ? new Date(
-        date.toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'numeric',
-          day: 'numeric',
-        })
-      )
-        .toISOString()
-        .split('T')[0]
-    : date.toLocaleDateString('en-US', {
-        month: 'long',
-        day: 'numeric',
-        year: 'numeric',
-      });
+// Returns the UTC calendar date of `input` as "YYYY-MM-DD".
+// Use where a machine-readable ISO date string is needed.
+export function toISODate(input: string | number): string {
+  return new Date(input).toISOString().split('T')[0];
 }
 
-// util function to format data in the following format "2023_08"
-export function formatDateString(
-  dateString: string | null | undefined,
-  isHyphenated = false
-) {
-  if (!dateString) {
-    return '';
-  }
-
-  if (isHyphenated) {
-    return dateString.replace('_', '-');
-  }
-
-  // Split the string into year and month parts
-  const [year, month] = dateString.split('_');
-
+// Parses a "YYYY_MM" period string into a Date at UTC midnight on the first
+// of the month, or null if the string is malformed.
+export function parsePeriodString(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const [year, month] = value.split('_');
   const yearNum = parseInt(year, 10);
   const monthNum = parseInt(month, 10);
 
@@ -53,23 +25,9 @@ export function formatDateString(
     monthNum < 1 ||
     monthNum > 12
   ) {
-    return '';
+    return null;
   }
-
-  // Create a Date object with the specified year and month (subtract 1 from the month, as months in JavaScript are zero-based)
-  const dateObject = new Date(yearNum, monthNum - 1);
-
-  if (Number.isNaN(dateObject.getTime())) {
-    return '';
-  }
-
-  // Format the date as "Month Year"
-  const formattedDate = new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    year: 'numeric',
-  }).format(dateObject);
-
-  return formattedDate;
+  return new Date(Date.UTC(yearNum, monthNum - 1));
 }
 
 export async function copyToClipboard(url: string): Promise<boolean> {
@@ -101,29 +59,6 @@ export function toTitleCase(str: string | null | undefined) {
   return str.toLowerCase().replace(/\b\w/g, function (char: string) {
     return char.toUpperCase();
   });
-}
-
-export function formatReferenceDate(
-  input: string | number | any,
-  isHyphenated = false
-): string {
-  const date = new Date(input);
-  // If hyphendated it would return date in this format - 2023-01-01 else in April 1, 2021
-  return isHyphenated
-    ? new Date(
-        date.toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'numeric',
-          // day: 'numeric',
-        })
-      )
-        .toISOString()
-        .split('T')[0]
-    : date.toLocaleDateString('en-US', {
-        month: 'long',
-        // day: 'numeric',
-        year: 'numeric',
-      });
 }
 
 export async function downloadStateReport(link: string, fileName: string) {

--- a/tests/analytics-mobile-layout.test.tsx
+++ b/tests/analytics-mobile-layout.test.tsx
@@ -131,7 +131,7 @@ jest.mock(
 jest.mock('@/lib/utils', () => ({
   cn: (...classes: string[]) => classes.filter(Boolean).join(' '),
   downloadStateReport: jest.fn(),
-  formatDate: jest.fn((timestamp) => '2023-08-01'),
+  toISODate: jest.fn((timestamp) => '2023-08-01'),
 }));
 
 jest.mock('@/hooks/use-copy-url', () => ({

--- a/tests/filter-component.test.tsx
+++ b/tests/filter-component.test.tsx
@@ -80,18 +80,12 @@ jest.mock('@/components/MobileFilterBox', () => ({
 
 // Mock utility functions
 jest.mock('@/lib/utils', () => ({
-  formatDate: jest.fn((timestamp: number, isHyphenated: boolean) => {
+  toISODate: jest.fn((timestamp: number) => {
     const date = new Date(timestamp);
     if (isNaN(date.getTime())) {
       return '2023-01-01'; // Return default date for invalid timestamps
     }
-    return isHyphenated
-      ? date.toISOString().split('T')[0]
-      : date.toLocaleDateString('en-US', {
-          month: 'long',
-          day: 'numeric',
-          year: 'numeric',
-        });
+    return date.toISOString().split('T')[0];
   }),
 }));
 

--- a/tests/filter-dropdown-options.test.tsx
+++ b/tests/filter-dropdown-options.test.tsx
@@ -33,19 +33,6 @@ jest.mock('opub-ui');
 
 // Mock utility functions
 jest.mock('@/lib/utils', () => ({
-  formatDate: jest.fn((timestamp: number, isHyphenated: boolean) => {
-    const date = new Date(timestamp);
-    if (isNaN(date.getTime())) {
-      return '2023-01-01'; // Return default date for invalid timestamps
-    }
-    return isHyphenated
-      ? date.toISOString().split('T')[0]
-      : date.toLocaleDateString('en-US', {
-          month: 'long',
-          day: 'numeric',
-          year: 'numeric',
-        });
-  }),
   toTitleCase: jest.fn((str: string) => {
     if (!str) return '';
     return str


### PR DESCRIPTION
- Extract date/time formats to i18n/formats.ts, imported by:
  - i18n/request.ts for server-side, via getRequestConfig
  - app/[locale]/layout.tsx for client-side, via <NextIntlClientProvider>
- Refactor formatReferenceDate() as useFormatPeriod(). Affects:
  - app/[locale]/components/resources.tsx
  - app/[locale]/datasets/components/DatasetCards.tsx
- Refactor formatDate(string) as format.dateTime(new Date(string), 'longDate'). Affects:
  - app/[locale]/components/stories.tsx
  - app/[locale]/datasets/[dataset]/components/Resources/index.tsx
- Refactor formatDate(string, true) as toISODate(string). Affects:
  - app/[locale]/[state]/analytics/components/filter-component.tsx
  This avoids a round-trip through toLocaleDateString() for no reason
- Refactor formatDateString() as parsePeriodString() + format.dateTime(). Affects:
  - app/[locale]/[state]/analytics/components/output-window.tsx
  Date.UTC fixes east-of-UTC clients rendering the prior month
  (e.g. "May 2024" → "Apr 2024" in IST).
