### PR TITLE
i18n: Add LocaleDropdown to switch configured locales

### DIFF
--- a/app/[locale]/[state]/analytics/components/analytics-sidebar-layout.tsx
+++ b/app/[locale]/[state]/analytics/components/analytics-sidebar-layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { Select, Spinner, Text } from 'opub-ui';
 

--- a/app/[locale]/[state]/analytics/components/filter-component.tsx
+++ b/app/[locale]/[state]/analytics/components/filter-component.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { parseDate } from '@internationalized/date';
 import { parseAsString, useQueryState } from 'next-usequerystate';
 import { useTranslations } from 'next-intl';

--- a/app/[locale]/components/analytics-quick-links.tsx
+++ b/app/[locale]/components/analytics-quick-links.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';

--- a/app/[locale]/components/dataset-catalog.tsx
+++ b/app/[locale]/components/dataset-catalog.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { getTranslations } from 'next-intl/server';
 import { Text } from 'opub-ui';
 

--- a/app/[locale]/components/resources.tsx
+++ b/app/[locale]/components/resources.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { captureException } from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import {

--- a/app/[locale]/components/stories.tsx
+++ b/app/[locale]/components/stories.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useFormatter, useTranslations } from 'next-intl';
 import {
   Carousel,

--- a/app/[locale]/datasets/[dataset]/components/Metadata/index.tsx
+++ b/app/[locale]/datasets/[dataset]/components/Metadata/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { Button, Icon, Tag, Text } from 'opub-ui';
 

--- a/app/[locale]/datasets/[dataset]/components/PrimaryData/index.tsx
+++ b/app/[locale]/datasets/[dataset]/components/PrimaryData/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { Button, Icon, Menu, Spinner, Text, Tray } from 'opub-ui';
 

--- a/app/[locale]/datasets/[dataset]/components/Resources/index.tsx
+++ b/app/[locale]/datasets/[dataset]/components/Resources/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { useFormatter, useTranslations } from 'next-intl';

--- a/app/[locale]/datasets/components/DatasetCards.tsx
+++ b/app/[locale]/datasets/components/DatasetCards.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { Button, Tag, Text, Tooltip } from 'opub-ui';
 

--- a/app/[locale]/datasets/page.tsx
+++ b/app/[locale]/datasets/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useReducer, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { captureException } from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import {

--- a/components/glossary/glossary-header-nav.tsx
+++ b/components/glossary/glossary-header-nav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { Icon, Text } from 'opub-ui';
 

--- a/components/langSelect/locale-select.tsx
+++ b/components/langSelect/locale-select.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+import { useLocale } from 'next-intl';
+import { IconWorld } from '@tabler/icons-react';
+import { Select } from 'opub-ui';
+
+import { locales } from '@/config/site';
+import { usePathname, useRouter } from '@/i18n/navigation';
+import styles from './styles.module.scss';
+
+export function LocaleDropdown() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentLocale = useLocale();
+
+  const options = React.useMemo(
+    () =>
+      locales.map((locale) => ({
+        label:
+          new Intl.DisplayNames(locale, { type: 'language' }).of(locale) ?? locale,
+        value: locale,
+      })),
+    []
+  );
+
+  return (
+    <Select
+      name="locale-select"
+      className={styles.langSelectContainer}
+      options={options}
+      label={
+        <div className="mr-2 flex justify-center">
+          <IconWorld color="white" />
+        </div>
+      }
+      labelInline
+      value={currentLocale}
+      onChange={(value: string) =>
+        router.replace(pathname, { locale: value })
+      }
+    />
+  );
+}

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -6,9 +6,10 @@ import { useKeyDetect } from '@/hooks/use-key-detect';
 import { useTranslations } from 'next-intl';
 import { Text } from 'opub-ui';
 
-import { languages, logo, mainNav } from '@/config/site';
+import { languages, locales, logo, mainNav } from '@/config/site';
 import { routes } from '@/lib/routes';
 import { TranslateDropdown } from './langSelect/lang-select';
+import { LocaleDropdown } from './langSelect/locale-select';
 import NavLink from './nav-link';
 
 export function MainNav({ prefLangCookie }: { prefLangCookie: string }) {
@@ -54,9 +55,11 @@ export function MainNav({ prefLangCookie }: { prefLangCookie: string }) {
             </div>
           )}
 
-          {languages.length > 0 && (
+          {languages.length > 0 ? (
             <TranslateDropdown prefLangCookie={prefLangCookie} />
-          )}
+          ) : locales.length > 1 ? (
+            <LocaleDropdown />
+          ) : null}
         </div>
       </div>
     </header>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import { useKeyDetect } from '@/hooks/use-key-detect';
 import { Credits, PartnerLogos } from '@/config/branding';
 import { logo, mainNav } from '@/config/site';

--- a/components/nav-link.tsx
+++ b/components/nav-link.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
+import { usePathname } from '@/i18n/navigation';
 
 import { Link } from '@/lib/router-events';
 

--- a/i18n/navigation.ts
+++ b/i18n/navigation.ts
@@ -1,0 +1,8 @@
+import { createNavigation } from 'next-intl/navigation';
+
+import { defaultLocale, locales } from '@/config/site';
+
+export const { Link, usePathname, useRouter } = createNavigation({
+  locales,
+  defaultLocale,
+});

--- a/lib/router-events/patch-router/link.tsx
+++ b/lib/router-events/patch-router/link.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
-import NextLink from 'next/link';
 
+import { Link as NextLink } from '@/i18n/navigation';
 import { onStart } from '../events';
 import { shouldTriggerStartEvent } from './should-trigger-start-event';
 

--- a/tests/analytics-quick-links.test.tsx
+++ b/tests/analytics-quick-links.test.tsx
@@ -23,10 +23,9 @@ jest.mock('next/image', () => ({
   },
 }));
 
-// Mock next/link to render an anchor tag directly
-jest.mock('next/link', () => ({
-  __esModule: true,
-  default: ({ href, children, ...rest }: any) => (
+// Mock @/i18n/navigation's locale-aware Link as a plain anchor for tests.
+jest.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: any) => (
     <a href={typeof href === 'string' ? href : href?.pathname} {...rest}>
       {children}
     </a>

--- a/tests/analytics-sidebar-layout.test.tsx
+++ b/tests/analytics-sidebar-layout.test.tsx
@@ -5,9 +5,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 // Mock opub-ui components
 jest.mock('opub-ui');
 
-// Mock next/navigation
+// The component uses next-intl's locale-aware useRouter via @/i18n/navigation.
 const mockPush = jest.fn();
-jest.mock('next/navigation', () => ({
+jest.mock('@/i18n/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 

--- a/tests/filter-component.test.tsx
+++ b/tests/filter-component.test.tsx
@@ -3,17 +3,18 @@ import { FilterComp } from '@/app/[locale]/[state]/analytics/components/filter-c
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-// Mock next/navigation
-// const mockPush = jest.fn();
+// FilterComp keeps useSearchParams on next/navigation but pulls useRouter
+// from next-intl via @/i18n/navigation, so each mock targets its source.
 const mockParams = jest.fn();
 const mockSearchParams = jest.fn();
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: () => {},
-  }),
   useParams: () => mockParams(),
   useSearchParams: () => mockSearchParams(),
+}));
+
+jest.mock('@/i18n/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
 }));
 
 // Mock next-usequerystate


### PR DESCRIPTION
If no `languages` (which control the `TranslateDropdown` Google Translate widget) are configured, then the site falls back to a `LocaleDropdown` if the user has specified `locales` in their config.

This uses URLs like /hi/ or /es/ beyond the currrent /en/.

This removes a hard dependency on proprietary software for a feature of the DPG.