### PR TITLE
perf: Change the user-visible behavior from "unmount, spinner, remount" to "swap in place"

### DIFF
--- a/app/[locale]/[state]/analytics/components/analytics-layout.tsx
+++ b/app/[locale]/[state]/analytics/components/analytics-layout.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { parseAsString, useQueryState } from 'next-usequerystate';
 import { useTranslations } from 'next-intl';
 import { Spinner, Tab, TabList, TabPanel, Tabs, Text } from 'opub-ui';
@@ -205,6 +205,7 @@ export function AnalyticsMainLayout() {
     enabled: Boolean(
       isMapView && currentSelectedState?.code && timePeriodSelected
     ),
+    placeholderData: keepPreviousData,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -230,6 +231,7 @@ export function AnalyticsMainLayout() {
     enabled: Boolean(
       isMapView && currentSelectedState?.code && timePeriodSelected
     ),
+    placeholderData: keepPreviousData,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -331,10 +333,25 @@ export function AnalyticsMainLayout() {
         } as any
       ),
     enabled: Boolean(isMapView && currentSelectedState?.code),
+    placeholderData: keepPreviousData,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
+
+  // Delay setting the map's indicator until all three per-indicator queries are fresh.
+  const [renderedIndicator, setRenderedIndicator] = useState(indicator);
+  if (
+    !mapData.isPlaceholderData &&
+    !revenueMapData.isPlaceholderData &&
+    !mapIndicatorsData.isPlaceholderData &&
+    mapData.data &&
+    revenueMapData.data &&
+    mapIndicatorsData.data &&
+    renderedIndicator !== indicator
+  ) {
+    setRenderedIndicator(indicator);
+  }
 
   // Data used for the state-level "About indicator" pane (always root list)
   const aboutIndicatorsData = useQuery<any>({
@@ -557,7 +574,7 @@ export function AnalyticsMainLayout() {
                   <>
                     {(statesListData?.isFetching ||
                       !timePeriodSelected ||
-                      (mapData?.isFetching && revenueMapData?.isFetching)) && (
+                      (mapData?.isLoading && revenueMapData?.isLoading)) && (
                       <div className="flex h-full flex-col place-content-center items-center">
                         <Spinner color="highlight" />
                         <Text>{tCommon('loading')}</Text>
@@ -566,9 +583,9 @@ export function AnalyticsMainLayout() {
 
                     {revenueMapData?.data && mapData?.data && (
                       <MapComponent
-                        indicator={indicator}
-                        mapDataloading={mapData?.isFetching}
-                        revenueMapDataLoading={revenueMapData?.isFetching}
+                        indicator={renderedIndicator}
+                        mapDataloading={mapData?.isLoading}
+                        revenueMapDataLoading={revenueMapData?.isLoading}
                         indicatorsData={mapIndicatorsData?.data?.indicators}
                         setRegion={setDistrictCode}
                         setRevenueRegion={setRevenueCode}
@@ -685,6 +702,7 @@ export function OutputWindowComponent({
           },
         }
       ),
+    placeholderData: keepPreviousData,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -702,26 +720,40 @@ export function OutputWindowComponent({
         }
       ),
     enabled: Boolean(currentState?.code),
+    placeholderData: keepPreviousData,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
 
+  // Delay setting the panel's indicator until both queries are fresh.
+  const [renderedIndicator, setRenderedIndicator] = useState(indicator);
+  if (
+    !sidePaneData.isPlaceholderData &&
+    !indicatorDescriptions.isPlaceholderData &&
+    sidePaneData.data &&
+    indicatorDescriptions.data &&
+    renderedIndicator !== indicator
+  ) {
+    setRenderedIndicator(indicator);
+  }
+
   return (
     <>
-      {sidePaneData?.isFetched && (
+      {sidePaneData?.data && (
         <OutputWindow
+          // During a district-to-subdistrict transition, the prior boundary's
+          // data is still in scope for one render; default to [] so the
+          // panel renders empty rather than crashing on the absent key.
           data={
-            sidePaneData?.data
-              ? sidePaneData?.data[
-                  !searchParams?.get('revenue-code')
-                    ? 'districtViewData'
-                    : 'revCircleViewData'
-                ]
-              : []
+            sidePaneData?.data?.[
+              !searchParams?.get('revenue-code')
+                ? 'districtViewData'
+                : 'revCircleViewData'
+            ] ?? []
           }
           indicatorDescriptions={indicatorDescriptions?.data?.indicators}
-          indicator={indicator}
+          indicator={renderedIndicator}
           boundary={boundary}
           currentState={currentState}
           onClose={onClose}

--- a/app/[locale]/[state]/analytics/components/map-component.tsx
+++ b/app/[locale]/[state]/analytics/components/map-component.tsx
@@ -62,7 +62,6 @@ export const MapComponent = ({
     );
   }, [tMap]);
   const [map, setMap] = React.useState<any>(null);
-  const [mapFeatures, setMapFeatures] = React.useState<any>(mapData.features);
   const [overlayFeatures, setOverlayFeatures] = React.useState<any>(null);
 
   React.useEffect(() => {
@@ -87,6 +86,14 @@ export const MapComponent = ({
 
   const params = new URLSearchParams(window.location.search);
   const districtCode = params.get('district-code');
+
+  const mapFeatures = React.useMemo(() => {
+    if (!districtCode) return mapData?.features;
+    return (revenueMapData?.features || []).filter(
+      (feature: { properties: { [x: string]: string } }) =>
+        feature.properties['district-code'] === districtCode
+    );
+  }, [districtCode, mapData?.features, revenueMapData?.features]);
 
   const { width } = useWindowSize();
   const isMobile = width < 1023;
@@ -259,13 +266,7 @@ export const MapComponent = ({
       });
     }
 
-    const filterMapData = revenueMapData?.features.filter(
-      (feature: { properties: { [x: string]: string } }) =>
-        feature.properties['district-code'] === districtCode
-    );
-
-    setMapFeatures(districtCode ? filterMapData : mapData?.features);
-  }, [districtCode, map, mapData?.features, revenueMapData?.features]);
+  }, [districtCode, map, mapData?.features]);
 
   React.useEffect(() => {
     if (!map) return;

--- a/app/[locale]/[state]/analytics/components/output-window.tsx
+++ b/app/[locale]/[state]/analytics/components/output-window.tsx
@@ -103,9 +103,11 @@ export function OutputWindow({
   // To filter out revenue circles from the district data boundary
   const DataBasedOnBoundary = !RevenueRegion ? districtData : data;
 
+  // `data` may briefly be [] during a district-to-subdistrict transition.
+  // The optional chaining yields undefined instead of throwing on `replace()`.
   const RegionName = !RevenueRegion
-    ? districtData[0]?.district
-    : data[0]?.[data[0].type.replace(/\s+/g, '-')];
+    ? districtData?.[0]?.district
+    : data?.[0]?.[data?.[0]?.type?.replace(/\s+/g, '-')];
 
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
 


### PR DESCRIPTION
- Use `placeholderData: keepPreviousData` and new `renderedIndicator` logic to:
  - Keep the previous GeoJSON visible while a new indicator's data is fetched,
    so the Leaflet container is not torn down on every indicator click.
    Affects: mapData (district GeoJSON), revenueMapData (subdistrict GeoJSON),
    mapIndicatorsData (indicators data)
  - Keep the previous panel visible while the new region's data is fetched, so
    the panel is not unmounted and visibly closed and reopened on every
    district/subdistrict click. Affects: sidePaneData
  - Keep the previous indicator's descriptions visible while a new indicator is
    fetched, to avoid a brief flash of a slug in the UI. Affects:
    indicatorDescriptions
- Change the spinner condition from isFetching to isLoading.
