### PR TITLE
fix: resolve CSV type errors by isolating ambient module declaration

### DIFF
--- a/types/csv.d.ts
+++ b/types/csv.d.ts
@@ -1,0 +1,4 @@
+declare module '*.csv' {
+  const content: string;
+  export default content;
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -13,8 +13,3 @@ declare global {
   type RiskLevel = keyof IntlMessages['analytics']['risk'];
   type NavLinkKey = keyof IntlMessages['nav']['links'];
 }
-
-declare module '*.csv' {
-  const content: string;
-  export default content;
-}


### PR DESCRIPTION
Move the *.csv ambient module declaration out of global.d.ts into a standalone csv.d.ts. Because global.d.ts has top-level imports, TypeScript treats it as a module rather than a global script, so the wildcard *.csv declaration wasn't reliably applied — causing type errors when importing CSV files from the india-branding package during build. Moving it to an import-free csv.d.ts fixes this.