### PR TITLE
test: Make i18n request test branding-independent

### DIFF
--- a/tests/i18n/request.test.ts
+++ b/tests/i18n/request.test.ts
@@ -12,6 +12,11 @@ jest.mock('@sentry/nextjs', () => ({
   captureException: jest.fn(),
 }));
 
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  locales: ['en'],
+}));
+
 import getRequestConfig from '@/i18n/request';
 
 describe('i18n request config', () => {


### PR DESCRIPTION
The set of valid locales is branding-derived (config.locales from the
installed ids-drr-branding package), so the test's hardcoded 'en' fails
under deployments that don't serve it (e.g. Paraguay ships es/gn). Mock
config/site to pin locales to ['en'] so the test is deterministic
regardless of which branding is installed.
