### PR TITLE
fix: Enable multi-month selection in the chart view on mobile

### DIFF
--- a/app/[locale]/[state]/analytics/components/analytics-mobile-layout.tsx
+++ b/app/[locale]/[state]/analytics/components/analytics-mobile-layout.tsx
@@ -271,6 +271,7 @@ export function AnalyticsMobileLayout({
             districtGeographiesData={districtGeographiesData}
             revenueGeographiesData={revenueGeographiesData}
             currentSelectedState={currentSelectedState}
+            monthMulti={view === 'chart'}
             // getDistrictOptions={getDistrictOptions}
           />
         </div>

--- a/app/[locale]/[state]/analytics/components/filter-component.tsx
+++ b/app/[locale]/[state]/analytics/components/filter-component.tsx
@@ -6,7 +6,15 @@ import { useRouter } from '@/i18n/navigation';
 import { parseDate } from '@internationalized/date';
 import { parseAsString, useQueryState } from 'next-usequerystate';
 import { useTranslations } from 'next-intl';
-import { Button, Icon, RadioGroup, RadioItem, YearCalendar } from 'opub-ui';
+import {
+  Button,
+  Icon,
+  MultiSelectYearCalendar,
+  RadioGroup,
+  RadioItem,
+  YearCalendar,
+} from 'opub-ui';
+import type { CalendarDate, DateValue } from '@internationalized/date';
 
 import { type State } from '@/config/graphql/analaytics-queries';
 import { routes, type AnalyticsView } from '@/lib/routes';
@@ -24,6 +32,7 @@ export function FilterComp({
   currentSelectedState,
   districtGeographiesData,
   revenueGeographiesData,
+  monthMulti = false,
   // getDistrictOptions,
 }: {
   timePeriod: string;
@@ -31,6 +40,7 @@ export function FilterComp({
   districtGeographiesData: JsonScalar;
   revenueGeographiesData: JsonScalar;
   currentSelectedState: State | null;
+  monthMulti?: boolean;
   // getDistrictOptions: any;
 }) {
   const t = useTranslations('analytics.filters');
@@ -191,6 +201,7 @@ export function FilterComp({
             timePeriodData={timePeriods}
             timePeriodSelected={timePeriodSelected}
             setTimePeriodSelected={setTimePeriodSelected}
+            monthMulti={monthMulti}
           />
         </MobileFilterContent>
       </MobileFilterBox>
@@ -208,6 +219,7 @@ const RenderOptions = ({
   timePeriodData,
   timePeriodSelected,
   setTimePeriodSelected,
+  monthMulti = false,
 }: {
   filterOptions: JsonScalar;
   selectedOption: string;
@@ -218,6 +230,7 @@ const RenderOptions = ({
   timePeriodData: JsonScalar;
   timePeriodSelected: string;
   setTimePeriodSelected: (value: string) => void;
+  monthMulti?: boolean;
 }) => {
   const t = useTranslations('analytics.filters');
   const [selectedState, setSelectedState] = useState('');
@@ -317,6 +330,53 @@ const RenderOptions = ({
         </RadioGroup>
       );
     case 'month-picker':
+      if (monthMulti) {
+        const selectedDates: CalendarDate[] = (timePeriodSelected || '')
+          .split(',')
+          .filter(Boolean)
+          .map((p) => {
+            const [year, month] = p.split('_');
+            if (!year || !month) return undefined;
+            return parseDate(
+              `${year}-${month.padStart(2, '0')}-01`
+            ) as CalendarDate;
+          })
+          .filter((d): d is CalendarDate => d !== undefined);
+        const periodYears = normalizedTimePeriods
+          .map((p: string) => parseInt(p.split('_')[0], 10))
+          .filter((y: number) => !isNaN(y));
+        const yearRange =
+          periodYears.length > 0
+            ? {
+                start: Math.min(...periodYears),
+                end: Math.max(...periodYears),
+              }
+            : undefined;
+        return (
+          <div className="self-center">
+            <MultiSelectYearCalendar
+              value={selectedDates}
+              yearRange={yearRange}
+              onChange={(dates: DateValue[]) => {
+                if (!dates || dates.length === 0) {
+                  setTimePeriodSelected('');
+                  return;
+                }
+                setTimePeriodSelected(
+                  dates
+                    .map(
+                      (d) =>
+                        `${d.year}_${
+                          d.month < 10 ? `0${d.month}` : `${d.month}`
+                        }`
+                    )
+                    .join(',')
+                );
+              }}
+            />
+          </div>
+        );
+      }
       return (
         <div className=" self-center">
           <YearCalendar


### PR DESCRIPTION
FilterComp was hardcoded to a single-month YearCalendar regardless of
view, while desktop's chart view uses MultiMonthPicker. Mobile chart
users could therefore only filter on one month at a time.

Pass monthMulti={view === 'chart'} from analytics-mobile-layout into
FilterComp, and render opub-ui's MultiSelectYearCalendar (the calendar
month grid that MultiMonthPicker wraps internally) inline in the filter
drawer when set.

The drawer is already a modal layer, so the popover wrapper would have
been a second modal — and it was also misbehaving on mobile (couldn't
open, overly wide).
