### PR TITLE
feat(analytics): filter available states in AnalyticsLayout

### DIFF
--- a/app/[locale]/[state]/analytics/layout.tsx
+++ b/app/[locale]/[state]/analytics/layout.tsx
@@ -2,6 +2,7 @@ import React, { cache } from 'react';
 import { notFound } from 'next/navigation';
 
 import { PLATFORM_STATES_LIST } from '@/config/graphql/analaytics-queries';
+import { states } from '@/config/site';
 import { getQueryClient, GraphQL } from '@/lib/api';
 import { AnalyticsSideBarLayout } from './components/analytics-sidebar-layout';
 
@@ -35,8 +36,18 @@ export default async function AnalyticsLayout({
   const resolvedParams = await params;
   const state = resolvedParams.state;
   const statesListData = await getStatesList();
+
+  const isActiveState = (state: string) => {
+    return states.some(
+      (item) => item.slug === state && item.status === 'active'
+    );
+  };
+  const availableStates = statesListData.filter((item) =>
+    isActiveState(item.slug)
+  );
+
   const currentState = statesListData?.find(
-    (item) => item.slug === state
+    (item) => item.slug === state && isActiveState(item.slug)
   );
 
   if (!currentState) notFound();
@@ -45,7 +56,7 @@ export default async function AnalyticsLayout({
     <>
       <AnalyticsSideBarLayout
         currentState={currentState}
-        statesList={statesListData}
+        statesList={availableStates}
       >
         {children}
         {/* {React.Children.map(children, child =>


### PR DESCRIPTION
Added a function to filter the states list to only include active states. Updated the current state check to ensure it only considers active states, and modified the statesList prop passed to AnalyticsSideBarLayout to use the filtered list of available states.