### PR TITLE
refactor(raster): Improve error handling in raster API responses

### DIFF
--- a/lib/raster.ts
+++ b/lib/raster.ts
@@ -37,6 +37,16 @@ export type RasterMetadata = {
   value_max?: number;
 };
 
+type RasterErrorResponse = {
+  error?: string;
+};
+
+async function throwIfRasterError(res: Response, context: string): Promise<void> {
+  if (res.ok) return;
+  const { error } = (await res.json()) as RasterErrorResponse;
+  throw new Error(error ?? `Raster ${context} ${res.status}`);
+}
+
 function rasterApiBase(): string {
   const base = process.env.NEXT_PUBLIC_DATA_MANAGEMENT_LAYER_URL ?? '';
   return base.replace(/\/$/, '');
@@ -97,9 +107,7 @@ export async function fetchRasterMetadata(
   }
 
   const res = await fetch(buildRasterMetadataUrl(params));
-  if (!res.ok) {
-    throw new Error(`Raster metadata ${res.status}: ${await res.text()}`);
-  }
+  await throwIfRasterError(res, 'metadata');
 
   return (await res.json()) as RasterMetadata;
 }
@@ -113,9 +121,7 @@ export async function fetchRasterValue(
   }
 
   const res = await fetch(buildRasterValueUrl(params));
-  if (!res.ok) {
-    throw new Error(`Raster value ${res.status}: ${await res.text()}`);
-  }
+  await throwIfRasterError(res, 'value');
 
   return (await res.json()) as RasterValueResponse;
 }

--- a/tests/lib/raster.test.ts
+++ b/tests/lib/raster.test.ts
@@ -78,15 +78,18 @@ describe('raster helpers', () => {
   });
 
   it('resolves tile URLs against the API base', () => {
-    expect(resolveTileUrl('https://tiles.example/{z}/{x}/{y}.png', 'http://localhost:8000')).toBe(
-      'https://tiles.example/{z}/{x}/{y}.png'
-    );
-    expect(resolveTileUrl('/tiles/{z}/{x}/{y}.png', 'http://localhost:8000')).toBe(
-      'http://localhost:8000/tiles/{z}/{x}/{y}.png'
-    );
-    expect(resolveTileUrl('tiles/{z}/{x}/{y}.png', 'http://localhost:8000')).toBe(
-      'http://localhost:8000/tiles/{z}/{x}/{y}.png'
-    );
+    expect(
+      resolveTileUrl(
+        'https://tiles.example/{z}/{x}/{y}.png',
+        'http://localhost:8000'
+      )
+    ).toBe('https://tiles.example/{z}/{x}/{y}.png');
+    expect(
+      resolveTileUrl('/tiles/{z}/{x}/{y}.png', 'http://localhost:8000')
+    ).toBe('http://localhost:8000/tiles/{z}/{x}/{y}.png');
+    expect(
+      resolveTileUrl('tiles/{z}/{x}/{y}.png', 'http://localhost:8000')
+    ).toBe('http://localhost:8000/tiles/{z}/{x}/{y}.png');
   });
 
   it('converts API bounds to leaflet bounds', () => {
@@ -178,11 +181,33 @@ describe('raster helpers', () => {
     process.env.NEXT_PUBLIC_DATA_MANAGEMENT_LAYER_URL = original;
   });
 
+  it('throws with the backend error message from a JSON body', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({
+        error:
+          "No raster data for state '21' in 'heat' indicator 'land-surface-temperature' at period '2026_06'.",
+      }),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      fetchRasterMetadata({
+        module: 'heat',
+        indicator: 'land-surface-temperature',
+        geography_code: '21',
+        period: '2026_06',
+      })
+    ).rejects.toThrow(
+      "No raster data for state '21' in 'heat' indicator 'land-surface-temperature' at period '2026_06'."
+    );
+  });
+
   it('throws when the raster API responds with an error', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 503,
-      text: async () => 'service unavailable',
+      json: async () => ({ error: 'service unavailable' }),
     }) as unknown as typeof fetch;
 
     await expect(
@@ -192,6 +217,6 @@ describe('raster helpers', () => {
         geography_code: '21',
         period: '2024_10',
       })
-    ).rejects.toThrow('Raster metadata 503: service unavailable');
+    ).rejects.toThrow('service unavailable');
   });
 });

--- a/tests/raster-map-component.test.tsx
+++ b/tests/raster-map-component.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { RasterMapComponent } from '@/components/analytics/raster-map-component';
 import { render, screen, waitFor } from '@testing-library/react';
 
+import { RasterMapComponent } from '@/components/analytics/raster-map-component';
 import { makeState } from './fixtures';
 
 const mockFetchRasterMetadata = jest.fn();
@@ -109,7 +109,9 @@ describe('RasterMapComponent', () => {
     render(<RasterMapComponent {...baseProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Unable to load raster layer.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Unable to load raster layer.')
+      ).toBeInTheDocument();
     });
     expect(screen.getByText('Raster unavailable')).toBeInTheDocument();
   });


### PR DESCRIPTION
- Introduced a new function `throwIfRasterError` to centralize error handling for raster API responses.
- Updated `fetchRasterMetadata` and `fetchRasterValue` to utilize the new error handling function.
- Enhanced tests to verify error messages from the backend are correctly thrown and displayed.